### PR TITLE
Remove 'co' dependency, use async/await instead

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -10,4 +10,4 @@ rules:
   prettier/prettier:
     - error
     - singleQuote: true
-      trailingComma: es5
+      trailingComma: all

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "homepage": "https://github.com/kiwicom/vault2env-js#readme",
   "dependencies": {
-    "co": "^4.6.0",
     "fs-extra": "^4.0.1",
     "minimist": "^1.2.0",
     "request": "^2.81.0",


### PR DESCRIPTION
Biggest simplification is visible in tests...

Closes #7 

Dammit! You know what is funny? That the `co` is not actually removed because it's dependency of other dependencies. So it should be renamed to: "Simplify the code usign async/await"... 🤦‍♂️ 